### PR TITLE
replace static::$macros[$method] with $macro

### DIFF
--- a/src/Macroable.php
+++ b/src/Macroable.php
@@ -51,11 +51,13 @@ trait Macroable
             throw new BadMethodCallException("Method {$method} does not exist.");
         }
 
-        if (static::$macros[$method] instanceof Closure) {
-            return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
+        $macro = static::$macros[$method];
+
+        if ($macro instanceof Closure) {
+            return call_user_func_array(Closure::bind($macro, null, static::class), $parameters);
         }
 
-        return call_user_func_array(static::$macros[$method], $parameters);
+        return call_user_func_array($macro, $parameters);
     }
 
     public function __call($method, $parameters)


### PR DESCRIPTION
This change improves readability and makes `__callStatic` and `__call` more consistent with each other.