### PR TITLE
Drop PHP 7.0 and PHP 7.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3, 7.2, 7.1, 7.0]
+                php: [8.0, 7.4, 7.3, 7.2]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.0|^8.0"
+        "php": "^7.2|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.3|^9.3"
+        "phpunit/phpunit": "^8.0|^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/tests/MacroableTest.php
+++ b/tests/MacroableTest.php
@@ -10,7 +10,7 @@ class MacroableTest extends TestCase
 {
     protected $macroableClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This will (hopefully) make the tests pass. I kept 7.2 because otherwise we can't use spatie-url for Cashier Paddle v1: https://github.com/laravel/cashier-paddle/blob/1.x/composer.json#L21