### PR TITLE
Improve PHPUnit fixture and ignore cached result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/tests/MacroableTest.php
+++ b/tests/MacroableTest.php
@@ -10,7 +10,7 @@ class MacroableTest extends TestCase
 {
     protected $macroableClass;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log

- Improve PHPUnit fixtures.
- Letting the `.phpunit.result.cache` file ignore Git version control because it's cached PHPUnit result file when running `vendor/bin/phpunit` with `PHPUnit 9.x` version.