### PR TITLE
Add PHP 8-only support (v2)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3, 7.2]
+                php: [8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `macroable` will be documented in this file
 
+## 2.0.0 - unreleased
+
+- require PHP 8+
+- drop support for PHP 7.x
+- convert syntax to PHP 8
+
 ## 1.0.1 - 2020-11-03
 
 - add support for PHP 8.0

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.3"

--- a/src/Macroable.php
+++ b/src/Macroable.php
@@ -9,7 +9,7 @@ use BadMethodCallException;
 
 trait Macroable
 {
-    protected static $macros = [];
+    protected static array $macros = [];
 
     /**
      * Register a custom macro.
@@ -17,7 +17,7 @@ trait Macroable
      * @param  string $name
      * @param  object|callable  $macro
      */
-    public static function macro(string $name, $macro)
+    public static function macro(string $name, object | callable $macro): void
     {
         static::$macros[$name] = $macro;
     }
@@ -25,9 +25,9 @@ trait Macroable
     /**
      * Mix another object into the class.
      *
-     * @param  object  $mixin
+     * @param  object|string  $mixin
      */
-    public static function mixin($mixin)
+    public static function mixin(object | string $mixin): void
     {
         $methods = (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED

--- a/src/Macroable.php
+++ b/src/Macroable.php
@@ -11,22 +11,11 @@ trait Macroable
 {
     protected static array $macros = [];
 
-    /**
-     * Register a custom macro.
-     *
-     * @param  string $name
-     * @param  object|callable  $macro
-     */
     public static function macro(string $name, object | callable $macro): void
     {
         static::$macros[$name] = $macro;
     }
 
-    /**
-     * Mix another object into the class.
-     *
-     * @param  object|string  $mixin
-     */
     public static function mixin(object | string $mixin): void
     {
         $methods = (new ReflectionClass($mixin))->getMethods(


### PR DESCRIPTION
This PR adds a new major version, v2.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removes redundant docblocks.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._