### PR TITLE
Added support for php7.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Hi @spatie

I've (re-?)added support for php 7.4 to the package. I think it would be nice to have the best possible support and since php7.4 will have security updates for nearly one more year it could be nice, if people could install `marcoable` in older projects.

I would be happy, if you could merge this, but I understand if it's not going to happen.

Best.
Maik Messerschmidt